### PR TITLE
Generate a combined MIZ file on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ You'll need to desanitize your DCS scripting environment, or else the Mission Ed
 1. Commit the changes in Git.
 1. Run `uv run tools/uninstall.py <theater>` to uninstall DCT and the theater files.
 
-### Addinga a New STM File
+`install.py` also generates an additional MIZ file named `dct-theaterName-combined.miz`. This file contains the base MIZ data and all templates (including all mutually exclusive variants) merged together. This is handy for visualizing where templates might be overlapping/in conflict, and what areas of the map are free to add more templates.
+
+### Adding a New STM File
 
 If you want to add a new mission template:
 

--- a/tools/uninstall.py
+++ b/tools/uninstall.py
@@ -19,13 +19,16 @@ def main():
     theater_folder = saved_games_folder / "theater"
     hook_file = saved_games_folder / "Scripts" / "Hooks" / "dct-hook.lua"
     cfg_file = saved_games_folder / "Config" / "dct.cfg"
-    mission_file = saved_games_folder / "Missions" / f"dct-{theater_name}.miz"
+    missions_folder = saved_games_folder / "Missions"
+    mission_file = missions_folder / f"dct-{theater_name}.miz"
+    combined_mission_file = missions_folder / f"dct-{theater_name}-combined.miz"
     state_file = saved_games_folder / "Caucasus_.state"
 
     try:
         print("Removing theater")
         state_file.unlink(missing_ok=True)
         mission_file.unlink(missing_ok=True)
+        combined_mission_file.unlink(missing_ok=True)
         if theater_folder.exists():
             shutil.rmtree(theater_folder)
 


### PR DESCRIPTION
Generates a handy MIZ with all STM variants merged in to visualize the full campaign.

![image](https://github.com/user-attachments/assets/673b1a10-cd1d-4244-8083-a081e435ee33)
